### PR TITLE
Optimize Dockerfile and added Git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM elixir:1.3-slim
 MAINTAINER Dimitris Zorbas "dimitrisplusplus@gmail.com"
 
-RUN echo Y | mix local.hex --force
-RUN mix hex.info
-RUN apt-get update
-RUN apt-get install curl xz-utils -y
+RUN mix local.hex --force && mix local.rebar --force
+RUN apt-get update \
+  && apt-get -yqq install curl xz-utils git \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
   && for key in \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Dimitris Zorbas "dimitrisplusplus@gmail.com"
 
 RUN mix local.hex --force && mix local.rebar --force
 RUN apt-get update \
-  && apt-get -yqq install curl xz-utils git \
+  && apt-get -qq install curl xz-utils git \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \


### PR DESCRIPTION
This started as a change to add Git so that developers will have it available if they need to install a dependency from GitHub. I then took it a step further to optimize the Dockerfile a bit for size by consolodating the `apt` commands to a single `RUN` statement and clearing the apt lists at the end. I also set it to install Rebar and not output the Hex info.

Differences of various Docker image sizes:

```
davejlong/kitto-with-git-optimized          latest              d1d86f631f4d        7 seconds ago        408.6 MB
davejlong/kitto-with-git                    latest              44dd48c4b9ad        About a minute ago   417.5 MB
davejlong/kitto-optimized                   latest              6be10bec9067        2 minutes ago        338.7 MB
davejlong/kitto                             latest              06dc96d33395        3 minutes ago        348.5 MB
```
