### PR TITLE
Add authentication to POST widgets/:id

### DIFF
--- a/installer/templates/new/config/config.exs
+++ b/installer/templates/new/config/config.exs
@@ -20,3 +20,8 @@ config :kitto, root: Path.dirname(__DIR__), port: 4000
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
+
+# Add authentication to `PORT /widgets/:id`. Change "asecret" to something more
+# secure.
+#
+# config :kitto, :auth_token: "asecret"

--- a/lib/kitto/router.ex
+++ b/lib/kitto/router.ex
@@ -32,11 +32,15 @@ defmodule Kitto.Router do
   end
 
   post "widgets/:id" do
-    {:ok, body, conn} = read_body(conn)
+    if authentication_required? && !authenticated?(conn) do
+      conn |> send_resp(401, "Authorization required") |> halt
+    else
+      {:ok, body, conn} = read_body(conn)
 
-    Kitto.Notifier.broadcast!(id, body |> Poison.decode!)
+      Kitto.Notifier.broadcast!(id, body |> Poison.decode!)
 
-    conn |> send_resp(204, "")
+      conn |> send_resp(204, "")
+    end
   end
 
   get "assets/*asset" do
@@ -101,4 +105,16 @@ defmodule Kitto.Router do
   end
 
   defp default_dashboard, do: Application.get_env(:kitto, :default_dashboard, "sample")
+
+  defp auth_token, do: Application.get_env(:kitto, :auth_token)
+
+  defp authentication_required?, do: !!auth_token
+
+  defp authenticated?(conn) do
+    auth_token == conn
+      |> get_req_header("authentication")
+      |> List.first
+      |> to_string
+      |> String.replace(~r/^Token\s/, "")
+  end
 end

--- a/lib/kitto/router.ex
+++ b/lib/kitto/router.ex
@@ -4,8 +4,8 @@ defmodule Kitto.Router do
   @development_assets_url "http://localhost:8080/assets/"
 
   if Mix.env == :dev, do: use Plug.Debugger, otp_app: :kitto
+  unless Mix.env == :test, do: plug Plug.Logger
 
-  plug Plug.Logger
   plug :match
   if Mix.env == :prod do
     plug Plug.Static, at: "assets", gzip: true, from: Path.join "public", "assets"

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -191,7 +191,7 @@ defmodule Kitto.RouterTest do
     body = %{elixir: "is awesome!"}
 
     conn = conn(:post, "widgets/#{topic}", Poison.encode!(body))
-      |> Kitto.Router.call @opts
+      |> Kitto.Router.call(@opts)
 
     assert conn.state == :sent
     assert conn.status == 401

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -170,4 +170,31 @@ defmodule Kitto.RouterTest do
       assert_receive :ok
     end
   end
+
+  test "with auth token post widgets/:id grants access when provided" do
+    Application.put_env :kitto, :auth_token, "asecret"
+    topic = "technology"
+    body = %{elixir: "is awesome!"}
+
+    conn = conn(:post, "widgets/#{topic}", Poison.encode!(body))
+      |> put_req_header("authentication", "Token asecret")
+      |> Kitto.Router.call(@opts)
+
+    assert conn.state == :sent
+    assert conn.status == 204
+    Application.delete_env :kitto, :auth_token
+  end
+
+  test "with auth token post widgets/:id denies access when not provided" do
+    Application.put_env :kitto, :auth_token, "asecret"
+    topic = "technology"
+    body = %{elixir: "is awesome!"}
+
+    conn = conn(:post, "widgets/#{topic}", Poison.encode!(body))
+      |> Kitto.Router.call @opts
+
+    assert conn.state == :sent
+    assert conn.status == 401
+    Application.delete_env :kitto, :auth_token
+  end
 end


### PR DESCRIPTION
To resolve #6, `POST widgets/:id` now supports token based
authentication. It can be configured through Mix with:

    config :kitto, auth_token: "mysecrettoken"

Setting the `auth_token` key will enforce authentication to `POST
widgets/:id` using the Authentication HTTP header:

    Authorization: Token mysecrettoken
