### PR TITLE
Abstract authentication into plug

### DIFF
--- a/lib/kitto/plugs/authentication.ex
+++ b/lib/kitto/plugs/authentication.ex
@@ -1,0 +1,60 @@
+defmodule Kitto.Plugs.Authentication do
+  @moduledoc """
+  Defines authentication logic for routes that require it. Authentication uses token based auth with
+  the Authentication header.
+
+  ## Setting up authentication:
+
+  To configure the dashboard with authentication, add the expected auth token to your application's
+  config:
+
+      # config/config.exs
+      config :kitto, auth_token: "asecret"
+
+  ## Authenticating requests
+
+  To authenticate requests that require it, pass the auth token in the Authentication header of
+  the request:
+
+      Authentication: Token asecret
+
+  An example cURL request to reload all dashboards with authentication:
+
+      $ curl -H "Authentication: Token asecret" -X POST http://localhost:4000/dashboards
+
+  ## Marking routes as authenticated
+
+  When adding new routes, to mark them as authenticated, add the `authenticated` key to the route's
+  private config:
+
+  get "my/authenticated/route", private: %{authenticated: true} do
+    # Process normal request
+  end
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _) do
+    if authentication_required?(conn) && !authenticated?(conn) do
+      conn |> send_resp(401, "Authorization required") |> halt
+    else
+      conn
+    end
+  end
+
+  defp authentication_required?(conn) do
+    !!auth_token && conn.private[:authenticated]
+  end
+
+  defp authenticated?(conn) do
+    auth_token == conn
+      |> get_req_header("authentication")
+      |> List.first
+      |> to_string
+      |> String.replace(~r/^Token\s/, "")
+  end
+
+  defp auth_token, do: Application.get_env(:kitto, :auth_token)
+end

--- a/test/plugs/authentication_test.exs
+++ b/test/plugs/authentication_test.exs
@@ -1,0 +1,63 @@
+defmodule Kitto.PlugAuthenticationTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  @opts Kitto.Plugs.Authentication.init([])
+
+  # NOTE: On tests that test whether the request is granted, the assertion is
+  # a little bit awkward. The test specifies that what's expected is that the
+  # connection should not be touched by the plug. Only when a request is
+  # denied should the plug stop the connection.
+  test "grants access when authenticated private param is not set" do
+    conn = conn(:post, "/widgets")
+
+    assert Kitto.Plugs.Authentication.call(conn, @opts) == conn
+  end
+
+  test "grants access when authenticated private param set to false" do
+    conn = conn(:post, "/widgets") |> put_private(:authenticated, false)
+
+    assert Kitto.Plugs.Authentication.call(conn, @opts) == conn
+  end
+
+  test "grants access when no auth_token set" do
+    conn = conn(:post, "/widgets") |> put_private(:authenticated, true)
+
+    assert Kitto.Plugs.Authentication.call(conn, @opts) == conn
+  end
+
+  test "grants access when auth token set without authenticated private param" do
+    Application.put_env :kitto, :auth_token, "asecret"
+    conn = conn(:post, "/dashboard")
+
+    assert Kitto.Plugs.Authentication.call(conn, @opts) == conn
+    Application.delete_env :kitto, :auth_token
+  end
+
+  test """
+  denies access when auth token and authenticated private param set without
+  authorization header provided
+  """ do
+    Application.put_env :kitto, :auth_token, "asecret"
+    conn = conn(:post, "/widgets")
+      |> put_private(:authenticated, true)
+      |> Kitto.Plugs.Authentication.call(@opts)
+
+    assert conn.status == 401
+    assert conn.state == :sent
+    Application.delete_env :kitto, :auth_token
+  end
+
+  test """
+  grants access when auth token and authenticated private param set with
+  authorization header provided
+  """ do
+    Application.put_env :kitto, :auth_token, "asecret"
+    conn = conn(:post, "/widgets")
+      |> put_private(:authenticated, true)
+      |> put_req_header("authentication", "Token asecret")
+
+    assert Kitto.Plugs.Authentication.call(conn, @opts) == conn
+    Application.delete_env :kitto, :auth_token
+  end
+end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -236,6 +236,16 @@ defmodule Kitto.RouterTest do
     Application.delete_env :kitto, :auth_token
   end
 
+  test "POST /dashboards/:id requires authentication" do
+    Application.put_env :kitto, :auth_token, "asecret"
+    conn = conn(:post, "dashboards/sample", "")
+      |> Kitto.Router.call(@opts)
+
+    assert conn.state == :sent
+    assert conn.status == 401
+    Application.delete_env :kitto, :auth_token
+  end
+
   test "POST /dashboards/:id reloads single dashboard" do
     dashboard = "sample"
     body = %{command: "reload"}
@@ -248,6 +258,16 @@ defmodule Kitto.RouterTest do
 
       assert_receive :ok
     end
+  end
+
+  test "POST /dashboards requires authentication" do
+    Application.put_env :kitto, :auth_token, "asecret"
+    conn = conn(:post, "dashboards", "")
+      |> Kitto.Router.call(@opts)
+
+    assert conn.state == :sent
+    assert conn.status == 401
+    Application.delete_env :kitto, :auth_token
   end
 
   test "POST /dashboards reloads all dashboards" do


### PR DESCRIPTION
Abstracting the authentication is intended as a first step towards reusability and less logic built directly into the `Router` module. The one thing I'm not super happy with is the `validate_request` method at [L#20](https://github.com/kittoframework/kitto/pull/15/files#diff-32b8f33789caed5ff4690a8e778dca7aR21). I'd like to implement. I'm going to remove the `authorize-widgets` branch because I managed to foobar it, merging master in.