### PR TITLE
Allow to specify the graph type in the graph.js example widget

### DIFF
--- a/installer/templates/new/dashboards/sample.html.eex
+++ b/installer/templates/new/dashboards/sample.html.eex
@@ -52,6 +52,7 @@
       <div class="widget-convergence"
            data-widget="Graph"
            data-source="convergence"
+           data-graph-type="line"
            data-title="Convergence"></div>
     </li>
   </ul>

--- a/installer/templates/new/widgets/graph/graph.js
+++ b/installer/templates/new/widgets/graph/graph.js
@@ -8,6 +8,10 @@ import {prettyNumber, prepend} from '../../assets/javascripts/helpers';
 import './graph.scss';
 
 Widget.mount(class Graph extends Widget {
+  static get defaultProps() {
+    return { graphType: 'area' };
+  }
+  
   componentDidMount() {
     this.$node = $(ReactDOM.findDOMNode(this));
     this.current = 0;
@@ -42,6 +46,12 @@ Widget.mount(class Graph extends Widget {
   currentValue() {
     return prettyNumber(prepend(this.current));
   }
+  getDefaultProps() {
+    return {
+      graphType: 'line'
+    };
+  }
+
   render() {
     return (
       <div className={this.props.className}>

--- a/installer/templates/new/widgets/graph/graph.js
+++ b/installer/templates/new/widgets/graph/graph.js
@@ -11,9 +11,9 @@ Widget.mount(class Graph extends Widget {
   componentDidMount() {
     this.$node = $(ReactDOM.findDOMNode(this));
     this.current = 0;
-    this.renderGraph();
+    this.renderGraph(this.props);
   }
-  renderGraph() {
+  renderGraph(props) {
     let container = this.$node.parent();
     let $gridster = $('.gridster');
     let widget_base_dimensions = $gridster.data('widget_base_dimensions');
@@ -25,6 +25,7 @@ Widget.mount(class Graph extends Widget {
       element: this.$node[0],
       width: width,
       height: height,
+      renderer: props.graphType,
       series: [{color: '#fff', data: [{ x: 0, y: 0 }]}]
     });
 


### PR DESCRIPTION
It sets the `renderer` option so you can specify all the different options from the docs: https://github.com/shutterstock/rickshaw#renderer

A question comes to mind: What about the other options? Is the idea to just give some basic widgets  to get the developer started or should we strive for more all purpose widgets. 

BTW my react knowledge is very low so It could be I crossed some boundaries 