### PR TITLE
Add command option to job definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ end
 The above will spawn a supervised process which will emit a [server-sent
 event](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) with the name `random` every second.
 
+Jobs can also run commands on the server. Data broadcast using commands is in
+the form `{exit_code: integer, stdout: String.t}`. For example the following
+job will broadcast a `kitto_last_commit` event with the results of the `curl`
+statement:
+
+```elixir
+job :kitto_last_commit,
+    every: {5, :minutes},
+    command: "curl https://api.github.com/repos/kittoframework/kitto/commits\?page\=1\&per_page\=1"
+```
+
 ## Widgets
 
 Widgets live in `widgets/` are compiled using


### PR DESCRIPTION
Adds support for running raw commands as jobs. Syntax of a job to run a command is:

```elixir
job :echo,
      every: {4, :minutes},
      command: "echo hello world"
```

The broadcasted event will be `echo` which will be an object with 2 keys: `exit_code` and `stdout`, containing the exit code of the command and the commands output respectively.

* [x] Add documentation of usage