### PR TITLE
Add support for `broadcast/1` to the job DSL

### DIFF
--- a/lib/kitto/job/dsl.ex
+++ b/lib/kitto/job/dsl.ex
@@ -61,7 +61,7 @@ defmodule Kitto.Job.DSL do
         else
           {:broadcast!, meta, args}
         end
-      node -> node
+      ast_node -> ast_node
     end
     block = Macro.prewalk(block, fix_broadcast)
 

--- a/lib/kitto/job/dsl.ex
+++ b/lib/kitto/job/dsl.ex
@@ -54,6 +54,17 @@ defmodule Kitto.Job.DSL do
     broadcast events using the jobs name.
   """
   defmacro job(name, options, do: block) do
+    fix_broadcast = fn
+      {:broadcast!, meta, args} ->
+        if Enum.count(args) == 1 do
+          {:broadcast!, meta, [name] ++ args}
+        else
+          {:broadcast!, meta, args}
+        end
+      node -> node
+    end
+    block = Macro.prewalk(block, fix_broadcast)
+
     quote do
       Job.register binding[:runner_server],
                    unquote(name),


### PR DESCRIPTION
The change will traverse the AST of the job and when it finds a call to `broadcast!/1` it converts it to `broadcast!/2` by inserting the job's name as the first argument.