### PR TITLE
Error pages

### DIFF
--- a/installer/lib/kitto_new.ex
+++ b/installer/lib/kitto_new.ex
@@ -18,6 +18,7 @@ defmodule Mix.Tasks.Kitto.New do
     {:text, "new/Procfile",                            "Procfile"},
     {:text, "new/elixir_buildpack.config",             "elixir_buildpack.config"},
     {:eex,  "new/lib/application_name.ex",             "lib/application_name.ex"},
+    {:text, "new/dashboards/error.html.eex",           "dashboards/error.html.eex"},
     {:text, "new/dashboards/layout.html.eex",          "dashboards/layout.html.eex"},
     {:text, "new/dashboards/sample.html.eex",          "dashboards/sample.html.eex"},
     {:text, "new/dashboards/jobs.html.eex",            "dashboards/jobs.html.eex"},

--- a/installer/templates/new/dashboards/error.html.eex
+++ b/installer/templates/new/dashboards/error.html.eex
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= code %> - <%= message %></title>
+
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <link rel="icon" href="/assets/favicon.ico">
+    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet" type="text/css">
+    <style>
+      html {
+        background-color: #222;
+        color: #fff;
+        font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+      .error {
+        background-color: #ec663c;
+        margin: 4em auto;
+        max-width: 30em;
+        padding: 4em 1em;
+        text-align: center;
+      }
+      .code {
+        color: rgba(255, 255, 255, 0.7);
+        font-size: 2em;
+        font-weight: 400;
+        margin: 0 0 .33em;
+      }
+      .message {
+        font-size: 1.5em;
+        font-weight: 600;
+        margin: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="error">
+      <h1 class="code"><%= code %></h1>
+      <h2 class="message"><%= message %></h2>
+    </div>
+  </body>
+</html>

--- a/lib/kitto/router.ex
+++ b/lib/kitto/router.ex
@@ -20,7 +20,7 @@ defmodule Kitto.Router do
     if View.exists?(id) do
       conn |> render(id)
     else
-      send_resp(conn, 404, "Dashboard \"#{id}\" does not exist")
+      render_error(conn, 404, "Dashboard \"#{id}\" does not exist")
     end
   end
 
@@ -64,7 +64,7 @@ defmodule Kitto.Router do
     if Mix.env == :dev do
       conn = conn |> redirect_to("#{development_assets_url}#{asset |> Enum.join("/")}")
     else
-      conn |> send_resp(404, "Not Found") |> halt
+      conn |> render_error(404, "Not Found") |> halt
     end
   end
 
@@ -77,9 +77,11 @@ defmodule Kitto.Router do
     |> send_cached_events
   end
 
-  match _, do: send_resp(conn, 404, "Not Found")
+  match _, do: render_error(conn, 404, "Not Found")
 
   defp render(conn, template), do: send_resp(conn, 200, View.render(template))
+
+  defp render_error(conn, code, message), do: send_resp(conn, code, View.render_error(code, message))
 
   defp listen_sse(conn, :""), do: listen_sse(conn, nil)
   defp listen_sse(conn, topics) do

--- a/lib/kitto/router.ex
+++ b/lib/kitto/router.ex
@@ -1,5 +1,6 @@
 defmodule Kitto.Router do
   use Plug.Router
+  use Plug.ErrorHandler
 
   alias Kitto.{View, Notifier}
 
@@ -78,6 +79,10 @@ defmodule Kitto.Router do
   end
 
   match _, do: render_error(conn, 404, "Not Found")
+
+  def handle_errors(conn, %{kind: _kind, reason: _reason, stack: _stack}) do
+    render_error(conn, 500, "Something went wrong")
+  end
 
   defp render(conn, template), do: send_resp(conn, 200, View.render(template))
 

--- a/lib/kitto/view.ex
+++ b/lib/kitto/view.ex
@@ -22,6 +22,13 @@ defmodule Kitto.View do
   end
 
   @doc """
+  Returns the EEx compiled output of the error template
+  """
+  def render_error(code, message) do
+    "error" |> path |> EEx.eval_file([code: code, message: message])
+  end
+
+  @doc """
   Returns true if the given template exists in the templates directory
   """
   def exists?(template), do: template |> path |> File.exists?

--- a/test/fixtures/views/error.html.eex
+++ b/test/fixtures/views/error.html.eex
@@ -1,0 +1,1 @@
+<div class="error"><%= code %> - <%= message %></div>

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -14,7 +14,7 @@ defmodule Kitto.RouterTest do
 
     assert conn.state == :sent
     assert conn.status == 404
-    assert conn.resp_body == "Not Found"
+    assert conn.resp_body == "<div class=\"error\">404 - Not Found</div>\n"
   end
 
   test "GET / with :default_dashboard left unconfigured redirects to dashboards/sample" do
@@ -73,7 +73,7 @@ defmodule Kitto.RouterTest do
 
     assert conn.state == :sent
     assert conn.status == 404
-    assert conn.resp_body == "Dashboard \"#{dashboard}\" does not exist"
+    assert conn.resp_body == "<div class=\"error\">404 - Dashboard \"#{dashboard}\" does not exist</div>\n"
   end
 
   test "GET /dashboards/:id when dashboard exists responds with 200 OK" do
@@ -342,6 +342,15 @@ defmodule Kitto.RouterTest do
 
       assert_receive :ok
     end
+  end
+
+  test "handle_errors" do
+    conn = conn(:get, "/")
+    conn = Kitto.Router.handle_errors(conn, %{kind: nil, reason: nil, stack: nil})
+
+    assert conn.state == :sent
+    assert conn.status == 500
+    assert conn.resp_body == "<div class=\"error\">500 - Something went wrong</div>\n"
   end
 
   def mock_broadcast(expected_topic, expected_body) do


### PR DESCRIPTION
For this: https://github.com/kittoframework/kitto/issues/41 - with all the pointers it was quite easy to set up, thanks @davejlong 

I've put together some basic pages now which look like:
![screen shot 2016-12-03 at 13 52 36](https://cloud.githubusercontent.com/assets/282717/20859760/110f7360-b960-11e6-897c-f17dca66666f.png)
![screen shot 2016-12-03 at 13 51 47](https://cloud.githubusercontent.com/assets/282717/20859761/11133036-b960-11e6-82c3-90e01d3da2eb.png)
 
Possible improvements could be applying HTML entities to the message.

Let me know if this is the way you were hoping to go on this 😊