### PR TITLE
Consider Kitto.root when serving static assets

### DIFF
--- a/lib/kitto/router.ex
+++ b/lib/kitto/router.ex
@@ -9,7 +9,7 @@ defmodule Kitto.Router do
   plug :match
   plug Kitto.Plugs.Authentication
   if Mix.env == :prod do
-    plug Plug.Static, at: "assets", gzip: true, from: Path.join "public", "assets"
+    plug Plug.Static, at: "assets", gzip: true, from: Path.join [Kitto.root, "public", "assets"]
   end
   plug :dispatch
 


### PR DESCRIPTION
This is necessary to use kitto in umbrella projects.
See bug #52