### PR TITLE
Check valid app name before creating application

### DIFF
--- a/installer/lib/kitto_new.ex
+++ b/installer/lib/kitto_new.ex
@@ -86,6 +86,7 @@ defmodule Mix.Tasks.Kitto.New do
       [] -> Mix.Task.run "help", ["kitto.new"]
       [path|_] ->
         app = Path.basename(Path.expand(path))
+        check_application_name!(app)
         mod = Macro.camelize(app)
 
         run(app, mod, path, opts)
@@ -157,6 +158,14 @@ defmodule Mix.Tasks.Kitto.New do
         $ npm install
     """
     nil
+  end
+
+  defp check_application_name!(app_name) do
+    unless app_name =~ ~r/^[a-z][\w_]*$/ do
+      Mix.raise "Application name must start with a letter and have only " <>
+                "lowercase letters, numbers and underscore, " <>
+                "received: #{inspect app_name}"
+    end
   end
 
   ### Helpers


### PR DESCRIPTION
Prior to this you could generate projects with a name such as "test-this" or "24pullrequests" which would create illegal Elixir module names.

The code for this is borrowed from [Pheonix Framework](https://github.com/phoenixframework/phoenix/blob/f2e02d97ef79f825f6bbbdc2d7b69a1d005bff90/installer/lib/phoenix_new.ex#L402-L415).