### PR TITLE
Make change rate tracker configurable on Number widget

### DIFF
--- a/installer/templates/new/widgets/number/number.js
+++ b/installer/templates/new/widgets/number/number.js
@@ -36,15 +36,22 @@ Widget.mount(class Number extends Widget {
       return '';
     }
   }
+  changeRate() {
+    if (this.props.changerate == "off") { return; }
+
+    return (
+      <p className="change-rate">
+        {this.arrow()}<span>{this.difference()}</span>
+      </p>
+    );
+  }
   render() {
     return (
       <div className={this.props.className}>
         <h1 className="title">{this.props.title}</h1>
         <h2 className="value"> {this.decorateValue(this.state.value)}</h2>
         <p className="more-info">{this.props.moreinfo}</p>
-        <p className="change-rate">
-          {this.arrow()}<span>{this.difference()}</span>
-        </p>
+        {this.changeRate()}
         <p className="updated-at">{updatedAt(this.state.updated_at)}</p>
       </div>
     );


### PR DESCRIPTION
I've noticed that tracking change rate on the number widget can be very confusing and does not contain enough information. This PR makes it so that the change rate tracking can be turned off.

In the future, we should show how long the change tracking is counting for: "⬆ 5% from 5 minutes ago"