### PR TITLE
Force fs to use rebar3 manager to fix error. See sync/fs#33

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Kitto.Mixfile do
     [{:cowboy, "~> 1.0.0"},
      {:plug, "~> 1.3"},
      {:poison, "~> 3.0"},
-     {:fs, github: "synrc/fs"},
+     {:fs, "~> 2.12.0"},
      {:httpoison, "~> 0.10.0"},
      {:ex_doc, "~> 0.14", only: :dev},
      {:credo, "~> 0.5", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Kitto.Mixfile do
     [{:cowboy, "~> 1.0.0"},
      {:plug, "~> 1.3"},
      {:poison, "~> 3.0"},
-     {:fs, "~> 2.11.0"},
+     {:fs, github: "synrc/fs", manager: :rebar3},
      {:httpoison, "~> 0.10.0"},
      {:ex_doc, "~> 0.14", only: :dev},
      {:credo, "~> 0.5", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Kitto.Mixfile do
     [{:cowboy, "~> 1.0.0"},
      {:plug, "~> 1.3"},
      {:poison, "~> 3.0"},
-     {:fs, github: "synrc/fs", manager: :rebar3},
+     {:fs, github: "synrc/fs"},
      {:httpoison, "~> 0.10.0"},
      {:ex_doc, "~> 0.14", only: :dev},
      {:credo, "~> 0.5", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "ex_doc": {:hex, :ex_doc, "0.14.4", "a0a79a6896075814f4bc6802b74ccbed6549f47cc5ab34c71eaee2303170b8ef", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.6", "35a903f6f78619ee7f951448dddfbef094b3a0d8581657afaf66465bc930468e", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
-  "fs": {:git, "https://github.com/synrc/fs.git", "6f2b38f57f2990164f446ab1c26e178e7dcfa2e2", []},
+  "fs": {:hex, :fs, "2.12.0", "ad631efacc9a5683c8eaa1b274e24fa64a1b8eb30747e9595b93bec7e492e25e", [:rebar3], []},
   "gettext": {:hex, :gettext, "0.11.0"},
   "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "ex_doc": {:hex, :ex_doc, "0.14.4", "a0a79a6896075814f4bc6802b74ccbed6549f47cc5ab34c71eaee2303170b8ef", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.6", "35a903f6f78619ee7f951448dddfbef094b3a0d8581657afaf66465bc930468e", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
-  "fs": {:hex, :fs, "2.11.0", "0dc1acc602e19de4075cfdf4cadbbb0a3316b2ee5f292d9f3ed1e26818f23f35", [:mix, :rebar3], []},
+  "fs": {:git, "https://github.com/synrc/fs.git", "6f2b38f57f2990164f446ab1c26e178e7dcfa2e2", []},
   "gettext": {:hex, :gettext, "0.11.0"},
   "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},


### PR DESCRIPTION
Fixes #65. An unreleased version of `fs` forces the `rebar3` manager to compile the dependency. See https://github.com/synrc/fs/issues/33