### PR TITLE
Update the order and injection of files

### DIFF
--- a/installer/templates/new/Dockerfile
+++ b/installer/templates/new/Dockerfile
@@ -1,12 +1,18 @@
 FROM zorbash/kitto
 
-ADD . /dashboard
-WORKDIR /dashboard
-
 ENV MIX_ENV prod
 
+RUN mkdir /dashboard
+WORKDIR /dashboard
+
+ADD ./mix.exs ./
+ADD ./mix.lock ./
 RUN mix deps.get
+
+ADD ./package.json ./
 RUN npm install
+
+ADD . /dashboard
 RUN npm run build
 RUN mix compile
 


### PR DESCRIPTION
This makes sure that you don't run npm install and mix deps.get on every build. The earlier shas will be cached by docker, took my average build time from ~9mins to around 3min unless I change package.json or mix