### PR TITLE
Testing/installation test

### DIFF
--- a/test/mix/tasks/kitto.new_test.exs
+++ b/test/mix/tasks/kitto.new_test.exs
@@ -1,0 +1,59 @@
+Code.require_file "../../../installer/lib/kitto_new.ex", __DIR__
+defmodule Mix.Tasks.Kitto.NewTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Kitto.FileAssertionHelper
+
+  setup do
+    Mix.Task.clear
+    # The shell asks to install npm and mix deps.
+    # We will politely say not.
+    send self(), {:mix_shell_input, :yes?, false}
+    :ok
+  end
+
+  test "when --version is provided, returns the current version" do
+    Mix.Tasks.Kitto.New.run(["--version"])
+    kitto_version = "Kitto v#{Mix.Project.config[:version]}"
+
+    assert_received {:mix_shell, :info, [^kitto_version] }
+  end
+
+  test "fails when invalid application name is provided" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Kitto.New.run(["dashboards@skidata"])
+    end
+  end
+
+  test "fails when only providing a switch" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Kitto.New.run(["-b"])
+    end
+  end
+
+  describe "when creating a new project" do
+    test "copies the files" do
+      in_tmp 'bootstrap', fn ->
+        Mix.Tasks.Kitto.New.run(["photo_dashboard"])
+
+        assert_received {:mix_shell, :info, ["* creating photo_dashboard/config/config.exs"]}
+      end
+    end
+
+    test "new project works" do
+      in_tmp 'bootstrap', fn ->
+        Mix.Tasks.Kitto.New.run(["photo_dashboard"])
+      end
+
+      in_project :photo_dashboard, Path.join(tmp_path, "bootstrap/photo_dashboard"), fn _ ->
+        Mix.Task.clear
+        Mix.Task.run "compile", ["--no-deps-check"]
+        Mix.shell.flush
+
+        {:ok, _} = Application.ensure_all_started(:photo_dashboard)
+        # Attempt to request the dashboard page, if this works everything is setup
+        assert %Plug.Conn{status: 200} = Kitto.Router.call(conn(:get, "/dashboards/sample"), [])
+      end
+    end
+  end
+end

--- a/test/support/file_assertion_helper.exs
+++ b/test/support/file_assertion_helper.exs
@@ -4,6 +4,7 @@ defmodule Kitto.FileAssertionHelper do
   https://github.com/phoenixframework/phoenix/blob/master/installer/test/mix_helper.exs
   """
   import ExUnit.Assertions
+  import ExUnit.CaptureIO
 
   def assert_file(file) do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
@@ -32,5 +33,15 @@ defmodule Kitto.FileAssertionHelper do
     File.rm_rf! path
     File.mkdir_p! path
     File.cd! path, function
+  end
+
+  def in_project(app, path, fun) do
+    %{name: name, file: file} = Mix.Project.pop
+
+    try do
+      capture_io :stderr, fn -> Mix.Project.in_project(app, path, [], fun) end
+    after
+      Mix.Project.push(name, file)
+    end
   end
 end


### PR DESCRIPTION
This adds a basic test fixing #35 and also attempts to fix #16 using delta's

I mimicked the way phoenix is testing its installer task. The only problem is that we don't generate a test directory. We don't provide any way for testing jobs (currently).

I didn't test that every file got written, rather I asserted that we could load the sample dashboard