### PR TITLE
Ignore conflicting module names in tests

### DIFF
--- a/test/mix/tasks/kitto.new_test.exs
+++ b/test/mix/tasks/kitto.new_test.exs
@@ -1,4 +1,6 @@
+Code.compiler_options(ignore_module_conflict: true)
 Code.require_file "../../../installer/lib/kitto_new.ex", __DIR__
+Code.compiler_options(ignore_module_conflict: false)
 
 defmodule Mix.Tasks.Kitto.NewTest do
   use ExUnit.Case, async: false


### PR DESCRIPTION
If the Kitto installer is already installed then running the test suite will generate the following warning:

```
warning: redefining module Mix.Tasks.Kitto.New (current version loaded from /Users/david/.kiex/mix/archives/elixir-1.3.4/kitto_new-0.3.1/kitto_new-0.3.1/ebin/Elixir.Mix.Tasks.Kitto.New.beam)
  installer/lib/kitto_new.ex:1
```

The change hides these warning in tests. If needed we can disable the warning only in `test/mix/tasks/kitto.new_test.exs`.