### PR TITLE
text widget changes (related to #80)

### DIFF
--- a/installer/templates/new/widgets/text/text.js
+++ b/installer/templates/new/widgets/text/text.js
@@ -1,15 +1,21 @@
 import React from 'react';
 import Widget from '../../assets/javascripts/widget';
+import {updatedAt} from '../../assets/javascripts/helpers';
 
 import './text.scss';
 
 Widget.mount(class Text extends Widget {
   render() {
+    let status = "";
+    if (this.state.widgetStatus) {
+      status = this.state.widgetStatus;
+    }
     return (
-      <div className={this.props.className}>
-        <h1 className="title">{this.props.title}</h1>
+      <div className={`${this.props.className} ${status}`}>    
+        <h1 className="title">{this.state.title || this.props.title}</h1>
         <h3>{this.state.text || this.props.text}</h3>
-        <p className="more-info">{this.props.moreinfo}</p>
+        <p className="more-info">{this.state.moreinfo || this.props.moreinfo}</p>
+        <p className="updated-at">{updatedAt(this.state.updated_at)}</p>
       </div>
     );
   }

--- a/installer/templates/new/widgets/text/text.js
+++ b/installer/templates/new/widgets/text/text.js
@@ -5,13 +5,13 @@ import {updatedAt} from '../../assets/javascripts/helpers';
 import './text.scss';
 
 Widget.mount(class Text extends Widget {
+  status() {
+    if (!this.state.status) { return ""; }    
+    return`status-${this.state.status}`;
+  }
   render() {
-    let status = "";
-    if (this.state.widgetStatus) {
-      status = this.state.widgetStatus;
-    }
     return (
-      <div className={`${this.props.className} ${status}`}>    
+      <div className={`${this.props.className} status-${status}`}>    
         <h1 className="title">{this.state.title || this.props.title}</h1>
         <h3>{this.state.text || this.props.text}</h3>
         <p className="more-info">{this.state.moreinfo || this.props.moreinfo}</p>

--- a/installer/templates/new/widgets/text/text.js
+++ b/installer/templates/new/widgets/text/text.js
@@ -7,11 +7,13 @@ import './text.scss';
 Widget.mount(class Text extends Widget {
   status() {
     if (!this.state.status) { return ""; }    
+    
     return`status-${this.state.status}`;
   }
+  
   render() {
     return (
-      <div className={`${this.props.className} status-${status}`}>    
+      <div className={`${this.props.className} ${this.status()}`}>    
         <h1 className="title">{this.state.title || this.props.title}</h1>
         <h3>{this.state.text || this.props.text}</h3>
         <p className="more-info">{this.state.moreinfo || this.props.moreinfo}</p>

--- a/installer/templates/new/widgets/text/text.scss
+++ b/installer/templates/new/widgets/text/text.scss
@@ -5,6 +5,7 @@ $background-color:  #ec663c;
 
 $title-color:       rgba(255, 255, 255, 0.7);
 $moreinfo-color:    rgba(255, 255, 255, 0.7);
+$updatedat-color:   rgba(255, 255, 255, 0.3);
 
 // ----------------------------------------------------------------------------
 // Widget-text styles
@@ -22,11 +23,11 @@ $moreinfo-color:    rgba(255, 255, 255, 0.7);
   }
 
   .updated-at {
-    color: rgba(255, 255, 255, 0.7);
+    color: $updatedat-color;
   }
 
-
-  &.large h3 {
-    font-size: 65px;
+  & h3 {
+    font-size: 25px;
   }
 }
+

--- a/installer/templates/new/widgets/text/text.scss
+++ b/installer/templates/new/widgets/text/text.scss
@@ -5,7 +5,7 @@ $background-color:  #ec663c;
 
 $title-color:       rgba(255, 255, 255, 0.7);
 $moreinfo-color:    rgba(255, 255, 255, 0.7);
-$updatedat-color:   rgba(255, 255, 255, 0.3);
+$updated-at-color:   rgba(0, 0, 0, 0.3);
 
 // ----------------------------------------------------------------------------
 // Widget-text styles
@@ -23,7 +23,7 @@ $updatedat-color:   rgba(255, 255, 255, 0.3);
   }
 
   .updated-at {
-    color: $updatedat-color;
+    color: $updated-at-color;
   }
 
   & h3 {


### PR DESCRIPTION
this is a cleaner PR than #80 

The biggest change from that PR other than cleaning up based on comments was that the application.scss already had a facility for data-driven status changes and I got rid of my custom style concept in favour of using the already built-in capability.

So now in the job you can pass:
```
...
widgetStatus: "status-warning" // or "status-danger"
```
and the widget will flash red or yellow.
@Zorbash - I notice this application.scss defines warning as red and danger as yellow. I feel like that's not intentional and they should be reversed. Do you want a PR for that?