### PR TITLE
swapped danger and warning colours

### DIFF
--- a/installer/templates/new/assets/stylesheets/application.scss
+++ b/installer/templates/new/assets/stylesheets/application.scss
@@ -7,12 +7,12 @@
 $background-color: #222;
 $text-color: #fff;
 
-$background-warning-color-1: #e82711;
-$background-warning-color-2: #9b2d23;
+$background-warning-color-1: #eeae32;
+$background-warning-color-2: #ff9618;
 $text-warning-color: #fff;
 
-$background-danger-color-1: #eeae32;
-$background-danger-color-2: #ff9618;
+$background-danger-color-1: #e82711;
+$background-danger-color-2: #9b2d23;
 $text-danger-color: #fff;
 
 @-webkit-keyframes status-warning-background {


### PR DESCRIPTION
As discussed in #82 , the Dashing-derived `application.scss` had amber for `danger` and red for `warning` statuses, which is really just wrong by most conventions.

This just simply swaps them.