### PR TITLE
Fix Elixir compiler warning in new projects

### DIFF
--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -7,7 +7,7 @@ defmodule <%= application_module %>.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application.


### PR DESCRIPTION
Fixes following warning in generated Kitto projects:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:10
```