### PR TITLE
Converts job names to atom

### DIFF
--- a/lib/kitto/job/dsl.ex
+++ b/lib/kitto/job/dsl.ex
@@ -54,6 +54,7 @@ defmodule Kitto.Job.DSL do
     broadcast events using the jobs name.
   """
   defmacro job(name, options, contents \\ []) do
+    name = if is_atom(name), do: name, else: String.to_atom(name)
     if options[:command] do
       _job(:shell, name, options)
     else

--- a/test/job/dsl_test.exs
+++ b/test/job/dsl_test.exs
@@ -16,4 +16,16 @@ defmodule Kitto.Job.DSLTest do
 
     assert expanded_ast |> String.match?(~r/broadcast!\(:valid, %{}\) end\)/)
   end
+
+  test "Converts job name to atom if it's a string" do
+    ast = quote do
+      job "valid", every: :second do
+        broadcast! :valid, %{}
+      end
+    end
+
+    expanded_ast = Macro.expand(ast, __ENV__) |> Macro.to_string
+
+    assert expanded_ast =~ ~r/Job.register\(binding\(\)\[:runner_server\], :valid/
+  end
 end


### PR DESCRIPTION
Fixes #98 by automatically changing job names to atoms.