### PR TITLE
Asserts that requested template is in the templates directory

### DIFF
--- a/lib/kitto/view.ex
+++ b/lib/kitto/view.ex
@@ -40,8 +40,15 @@ defmodule Kitto.View do
   @doc """
   Returns true if the given template exists in the templates directory
   """
-  def exists?(template), do: template |> path |> File.exists?
+  def exists?(template) do
+    file = template |> path
+    File.exists?(file) && !(invalid_path?(template |> Path.split))
+  end
 
-  defp path(template), do: Path.join templates_path(), "#{template}.html.eex"
+  defp path(template), do: Path.join(templates_path(), "#{template}.html.eex")
   defp templates_path, do: Path.join Kitto.root, @templates_dir
+
+  defp invalid_path?([h|_]) when h in [".", "..", ""], do: true
+  defp invalid_path?([h|t]), do: String.contains?(h, ["/", "\\", ":", "\0"]) or invalid_path?(t)
+  defp invalid_path?([]), do: false
 end

--- a/test/view_test.exs
+++ b/test/view_test.exs
@@ -2,25 +2,36 @@ defmodule Kitto.ViewTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  test "#render(template) renders layout with the given assigns" do
-    html = "<div class=\"layout blue\"><h1>Hello from kitto</h1>\n\n</div>\n"
+  describe ".render/1" do
+    test "renders layout with the given assigns" do
+      html = "<div class=\"layout blue\"><h1>Hello from kitto</h1>\n\n</div>\n"
 
-    assert Kitto.View.render("sample", color: "blue") == html
+      assert Kitto.View.render("sample", color: "blue") == html
+    end
+
+    test "renders template with the given assigns" do
+      html = "<div class=\"layout green\"><h1>Hello from kitto</h1>" <>
+             "\n\n  <h2>Hello from contributor</h2>\n\n</div>\n"
+      assigns = [color: "green", user: "contributor"]
+
+      assert Kitto.View.render("sample", assigns) == html
+    end
   end
 
-  test "#render(template) renders template with the given assigns" do
-    html = "<div class=\"layout green\"><h1>Hello from kitto</h1>" <>
-           "\n\n  <h2>Hello from contributor</h2>\n\n</div>\n"
-    assigns = [color: "green", user: "contributor"]
+  describe ".exists?/1" do
+    test "when the template exists, returns true" do
+      assert Kitto.View.exists?("sample")
+    end
 
-    assert Kitto.View.render("sample", assigns) == html
-  end
+    test "when the template does not exist, returns false" do
+      refute Kitto.View.exists?("does_not_exist")
+    end
 
-  test "#exists?(template) when the template exists, returns true" do
-    assert Kitto.View.exists?("sample")
-  end
-
-  test "#exists?(template) when the template does not exist, returns false" do
-    refute Kitto.View.exists?("does_not_exist")
+    test "when the template is not in dashboards, returns false" do
+      refute Kitto.View.exists?("../../../mix.exs")
+      refute Kitto.View.exists?("/etc/passwd")
+      refute Kitto.View.exists?("../../../mix.exs\0")
+      refute Kitto.View.exists?("/etc/passwd\0")
+    end
   end
 end


### PR DESCRIPTION
Closes a remote file read vulnerability where a user could break out of the
templates directory and read other files on the host.