### PR TITLE
Adds the edge and dev switches to `mix kitto.install`

### DIFF
--- a/installer/lib/kitto_new.ex
+++ b/installer/lib/kitto_new.ex
@@ -70,7 +70,22 @@ defmodule Mix.Tasks.Kitto.New do
   end
 
   @moduledoc """
-  Kitto installer. Generates a scaffolding to build a new dashboard upon.
+  Creates a new Kitto dashboard.
+
+  It expects the path of the project as argument.
+
+      mix kitto.new PATH [--edge]
+
+  A project at the given PATH will be created. The application name and module
+  name will be retrieved from the path.
+
+  ## Options
+
+  * `--edge` - use the `master` branch of Kitto as your dashboard's dependency
+
+  ## Examples
+
+      mix kitto.new hello_world
 
   See: https://github.com/kittoframework/demo
   """
@@ -81,7 +96,7 @@ defmodule Mix.Tasks.Kitto.New do
 
   def run(argv) do
     {opts, argv} =
-      case OptionParser.parse(argv) do
+      case OptionParser.parse(argv, switches: [edge: :boolean]) do
         {opts, argv, []} ->
           {opts, argv}
         {_opts, _argv, [switch | _]} ->
@@ -99,10 +114,10 @@ defmodule Mix.Tasks.Kitto.New do
     end
   end
 
-  def run(app, mod, path, _opts) do
+  def run(app, mod, path, opts) do
     binding = [application_name: app,
                application_module: mod,
-               kitto_dep: kitto_dep(kitto_path(path, false))]
+               kitto_dep: kitto_dep(opts[:edge])]
 
     copy_from path, binding, @new
 
@@ -196,12 +211,8 @@ defmodule Mix.Tasks.Kitto.New do
     :os.cmd(String.to_char_list(cmd))
   end
 
-  defp kitto_dep("deps/kitto"), do: ~s[{:kitto, "~> #{@version}"}]
-  defp kitto_dep(path), do: ~s[{:kitto, path: #{inspect path}, override: true}]
-
-  defp kitto_path(_path, false) do
-    "deps/kitto"
-  end
+  defp kitto_dep(true), do: ~s[{:kitto, github: "kittoframework/kitto", branch: "master"}]
+  defp kitto_dep(_), do: ~s[{:kitto, "~> #{@version}"}]
 
   ### Template helpers
 

--- a/installer/lib/kitto_new.ex
+++ b/installer/lib/kitto_new.ex
@@ -75,20 +75,24 @@ defmodule Mix.Tasks.Kitto.New do
 
   It expects the path of the project as argument.
 
-      mix kitto.new PATH [--edge] [--dev KITTO_PATH]
+      mix kitto.new PATH [--edge] [--dev KITTO_PATH] [--app APP_NAME]
 
   A project at the given PATH will be created. The application name and module
-  name will be retrieved from the path.
+  name will be retrieved from the path, unless otherwise provided.
 
   ## Options
 
   * `--edge` - use the `master` branch of Kitto as your dashboard's dependency
   * `--dev` - use a local copy of Kitto as your dashboard's dependency
+  * `--app` - name of the OTP application and base module
 
   ## Examples
 
       # Create a new Kitto dashboard
       mix kitto.new hello_world
+
+      # Create a new Kitto dashboard named `Foo` in `./hello_world`
+      mix kitto.new hello_world --app foo
 
       # Create a new Kitto dashboard using the master branch to get the latest
       # Kitto features
@@ -107,7 +111,7 @@ defmodule Mix.Tasks.Kitto.New do
 
   def run(argv) do
     {opts, argv} =
-      case OptionParser.parse(argv, switches: [edge: :boolean, dev: :string]) do
+      case OptionParser.parse(argv, switches: [edge: :boolean, dev: :string, app: :string]) do
         {opts, argv, []} ->
           {opts, argv}
         {_opts, _argv, [switch | _]} ->
@@ -117,7 +121,7 @@ defmodule Mix.Tasks.Kitto.New do
     case argv do
       [] -> Mix.Task.run "help", ["kitto.new"]
       [path|_] ->
-        app = Path.basename(Path.expand(path))
+        app = (opts[:app] || Path.basename(Path.expand(path))) |> String.downcase
         check_application_name!(app)
         mod = Macro.camelize(app)
 

--- a/installer/templates/new/package.json
+++ b/installer/templates/new/package.json
@@ -21,7 +21,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "kitto": "file:deps/kitto",
+    "kitto": "file:<%= npm_kitto_dep %>",
     "webpack": "^1.12.13",
     "webpack-merge": "^0.15.0",
     "compression-webpack-plugin": "0.3.1",


### PR DESCRIPTION
Fixes #106

CLI will now have the following option:

```
mix kitto.new foo_bar --edge # <= Creates a new dashboard at `foo_bar` using `{:kitto, github: "kittoframework/kitto", branch: "master"}` as the dependency
mix kitto.new foo_bar --dev my_kitto # <= Creates a new dashboard at `foo_bar` using `{:kitto, path: "$PWD/my_kitto"}` as the dependency
```

The path for the `--dev` switch is expanded from the current working directory of the running `mix kitto.new` command, so if you run `mix kitto.new foo_bar --dev my_kitto` from `/Users/davejlong/projects` it will install the new dashboard at `/Users/davejlong/projects/foo_bar` and use Kitto at (or clone Kitto to) `/Users/davejlong/projects/my_kitto`