### PR TITLE
Add note to compile application for generators

### DIFF
--- a/installer/lib/kitto_new.ex
+++ b/installer/lib/kitto_new.ex
@@ -174,6 +174,10 @@ defmodule Mix.Tasks.Kitto.New do
 
         #{Enum.join(steps, "\n    ")}
 
+    To access generators compile your application first with:
+
+        $ mix compile
+
     You can also run your app inside IEx (Interactive Elixir) as:
 
         $ iex -S mix


### PR DESCRIPTION
A quick fix to #101 so that developers know to compile their application before they'll get the generators.