### PR TITLE
Fullscreen button

### DIFF
--- a/installer/templates/new/assets/javascripts/application.js
+++ b/installer/templates/new/assets/javascripts/application.js
@@ -2,7 +2,20 @@ import '../stylesheets/application.scss';
 
 import $ from 'jquery';
 import {Kitto} from 'kitto';
+import fscreen from 'fscreen';
 
 window.jQuery = window.$ = $;
 
 Kitto.start();
+
+var i = null;
+$("body").mousemove(function() {
+    clearTimeout(i);
+    $(".fullscreen-button").addClass("active");
+    i = setTimeout('$(".fullscreen-button").removeClass("active");', 1000);
+})
+
+$(".fullscreen-button").click(function() {
+  var ele = document.getElementById("container");
+  fscreen.requestFullscreen(ele);
+})

--- a/installer/templates/new/assets/stylesheets/application.scss
+++ b/installer/templates/new/assets/stylesheets/application.scss
@@ -197,6 +197,19 @@ h3 {
   padding-top: 5px;
 }
 
+.fullscreen-button {
+  cursor: pointer;
+  position: fixed;
+  right: 5px;
+  top: 5px;
+  opacity: 0;
+  transition: opacity 0.5s ease-out;
+
+  &.active {
+    opacity: 1;
+  }
+}
+
 // ----------------------------------------------------------------------------
 // Clearfix
 // ----------------------------------------------------------------------------

--- a/installer/templates/new/dashboards/layout.html.eex
+++ b/installer/templates/new/dashboards/layout.html.eex
@@ -16,6 +16,8 @@
       <%= @template %>
     </div>
 
+    <i class="fullscreen-button fa fa-arrows-alt"></i>
+
     <script type="text/javascript" src="/assets/application.js"></script>
     <script type="text/javascript" src="/assets/widgets.js"></script>
   </body>

--- a/installer/templates/new/package.json
+++ b/installer/templates/new/package.json
@@ -48,6 +48,7 @@
     "imports": "^1.0.0",
     "rickshaw": "1.6.0",
     "jquery": "2.2.3",
-    "jquery-knob": "1.2.11"
+    "jquery-knob": "1.2.11",
+    "fscreen": "^1.0.2"
   }
 }


### PR DESCRIPTION
Add a button to enable full screen mode. (Closes #19 )

The tiny icon in the top right:
![image](https://user-images.githubusercontent.com/4751193/31590334-257cd91c-b1c3-11e7-8e09-bf383a9e7b6b.png)

Test it out [here](https://shrouded-beyond-31431.herokuapp.com/dashboards/sample)!

The fullscreen API is a bit of mess across multiple browsers so it uses the [fscreen](https://github.com/rafrex/fscreen) library to handle the api call. This is the library recommended in [the mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API).

Since we want the button to show up when moving the mouse anywhere on the screen it listens to mouse move events on `body`. There doesn't seem to be a place for internal react components so while the button could be a component I think it makes more sense to just have the onClick listener.
