### PR TITLE
Fix erlang version in heroku buildpack

### DIFF
--- a/installer/templates/new/elixir_buildpack.config
+++ b/installer/templates/new/elixir_buildpack.config
@@ -1,1 +1,2 @@
+erlang_version=19.3
 elixir_version=1.3.0


### PR DESCRIPTION
The buildpack would install the latest version of erlang by default which is not compatible with the version of elixir we have pinned and would cause the build to fail. Setting the erlang version to 19.3 matches the version used in the docker file.