### PR TITLE
Fixed webpack to close with kitto.server

### DIFF
--- a/lib/mix/tasks/kitto.server.ex
+++ b/lib/mix/tasks/kitto.server.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Kitto.Server do
   require Logger
 
   @watchers webpack: [bin: "./node_modules/.bin/webpack-dev-server",
-                      opts: ["--stdin", "--progress"]]
+                      opts: ["--watch", "--progress", "--colors"]]
 
   @shortdoc "Starts applications and their servers"
 


### PR DESCRIPTION
The `--stdin` flag wasn't added until a later version that the default for webpack-dev-server. This is meant as a hotfix for the larger task of updating Webpack.