### PR TITLE
provide content-type for dashboard html

### DIFF
--- a/lib/kitto/router.ex
+++ b/lib/kitto/router.ex
@@ -43,7 +43,9 @@ defmodule Kitto.Router do
     path = Enum.join(id, "/")
 
     if View.exists?(path) do
-      conn |> render(path)
+      conn
+      |> put_resp_header("content-type", "text/html")
+      |> render(path)
     else
       render_error(conn, 404, "Dashboard does not exist")
     end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -22,7 +22,7 @@ defmodule Kitto.RouterTest do
     assert conn.status == 404
     assert conn.resp_body == "<div class=\"error\">404 - Not Found</div>\n"
   end
-  
+
   test "GET with unrecognized request path in nested folder responds with 404 Not Found" do
     conn = conn(:get, "/dashboards/folder/nope")
 
@@ -83,7 +83,7 @@ defmodule Kitto.RouterTest do
 
   test "GET with request path in nested folder responds with 200 when the template exists" do
     conn = conn(:get, "/dashboards/folder/sample")
-    
+
     conn = Kitto.Router.call(conn, @opts)
 
     assert conn.state == :sent
@@ -148,6 +148,7 @@ defmodule Kitto.RouterTest do
 
       assert conn.state == :sent
       assert conn.status == 200
+      assert List.keyfind(conn.resp_headers, "content-type", 0) == {"content-type", "text/html"}
       assert conn.resp_body == view
     end
   end


### PR DESCRIPTION
We found that if we serve kitto dashboard behind nginx, chrome or safari will download the dashboard, rather than serving it as an html page. The reason is "content-type" of response is not properly set by kitto.